### PR TITLE
Allow creating adversaries from layers without tactics.

### DIFF
--- a/app/compass_svc.py
+++ b/app/compass_svc.py
@@ -88,8 +88,12 @@ class CompassService:
         atomic_order = []
         unmatched_techniques = []
         for technique_id, tactic in adversary_techniques:
-            abilities = await self.data_svc.locate('abilities', match=dict(technique_id=technique_id,
-                                                                           tactic=tactic))
+            if tactic:
+                abilities = await self.data_svc.locate('abilities', match=dict(technique_id=technique_id,
+                                                                               tactic=tactic))
+            else:
+                abilities = await self.data_svc.locate('abilities', match=dict(technique_id=technique_id))
+
             if not abilities:
                 unmatched_techniques.append(dict(technique_id=technique_id, tactic=tactic))
             for ab in abilities:


### PR DESCRIPTION
Allow creating adversaries from layers without tactics.  This matches the layer format that can be downloaded from attack.mitre.org.  When one of these sparse layers is displayed in the att&ck-navigator, the navigator will infer all possible tactic mappings in the same way as this PR. 

Confirmed with @isaisabel that this is the expected behavior from the att&ck navigator, so I think compass should match it (otherwise the group layer files downloaded from attack.mitre.org don't work with the plugin).