### PR TITLE
fix: raise instead of return HTTPBadRequest on JSON decode error in compass_svc

### DIFF
--- a/app/compass_svc.py
+++ b/app/compass_svc.py
@@ -127,7 +127,7 @@ class CompassService:
         try:
             request_body = await self._read_layer(request)
         except json.decoder.JSONDecodeError:
-            return web.HTTPBadRequest()
+            raise web.HTTPBadRequest()
         try:
             adversary_data = dict(id=str(uuid.uuid4()),
                                   name=request_body.get('name'),


### PR DESCRIPTION
## Summary

`create_adversary_from_layer()` in `compass_svc.py` was *returning* `web.HTTPBadRequest()` when a `JSONDecodeError` was caught, instead of *raising* it.

**Before:**
```python
except json.decoder.JSONDecodeError:
    return web.HTTPBadRequest()
```

**After:**
```python
except json.decoder.JSONDecodeError:
    raise web.HTTPBadRequest()
```

## Impact

In aiohttp, HTTP exception objects must be **raised** to be intercepted by the framework and sent as an HTTP response. When the exception object is returned instead, aiohttp receives `None` from the handler (since the function continues past the return), resulting in a **500 Internal Server Error** being returned to the client instead of the intended **400 Bad Request**.

Any client that submits a malformed or non-JSON layer file to the `create_adversary_from_layer` endpoint receives a misleading 500 error rather than a clear 400 error indicating a client-side problem.

Note: the `except Exception` block at the bottom of the same function correctly uses `raise web.HTTPBadRequest()` — this fix makes the `JSONDecodeError` path consistent.

## Test plan
- [ ] Submit a non-JSON file to the compass layer upload endpoint and confirm a 400 response is returned
- [ ] Submit a valid JSON layer file and confirm adversary creation still works